### PR TITLE
Fix string literal warning for method missing

### DIFF
--- a/lib/x12/base.rb
+++ b/lib/x12/base.rb
@@ -147,7 +147,7 @@ module X12
 
     # The main method implementing Ruby-like access methods for nested elements
     def method_missing(meth, *args, &block)
-      str = meth.id2name
+      str = String.new(meth.id2name)
       str = str[1..str.length] if str =~ /^_\d+$/ # to avoid pure number names like 270, 997, etc.
       #puts "Missing #{str}"
       if str =~ /=$/


### PR DESCRIPTION
ruby 3.4.3 is throwing deprecation warnings for string literals. str.chop! Modifies the string in place, we need a dynamic string. So I concert the literal string into a dynamic one.